### PR TITLE
fix(Observer): fix Observable#subscribe() signature to suggest correct usable

### DIFF
--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -82,6 +82,9 @@ export class Observable<T> implements Subscribable<T> {
    * @param {Function} complete (optional) a handler for a terminal event resulting from successful completion.
    * @return {ISubscription} a subscription reference to the registered handlers
    */
+  subscribe(): Subscription;
+  subscribe(observer: PartialObserver<T>): Subscription;
+  subscribe(next?: (value: T) => void, error?: (error: any) => void, complete?: () => void): Subscription;
   subscribe(observerOrNext?: PartialObserver<T> | ((value: T) => void),
             error?: (error: any) => void,
             complete?: () => void): Subscription {


### PR DESCRIPTION
**Description:**

This was annoying me a long time already. So this patch describes better how to call the `.subscribe()` method, ruling out invalid combinations (like a partial observer object and an error handler).
- Overloads subscribe signature for usage with an empty subscriber, PartialObserver<T>, or next, error and complete handlers
